### PR TITLE
fix: affine gradient propagation

### DIFF
--- a/models/modules.py
+++ b/models/modules.py
@@ -236,10 +236,8 @@ class AffineTransform(nn.Module):
         
     def zero_init(self):
         torch.nn.init.zeros_(self.embedding.weight)
-        for layer in self.decoder:
-            if isinstance(layer, nn.Linear):
-                torch.nn.init.zeros_(layer.weight)
-                torch.nn.init.zeros_(layer.bias)
+        torch.nn.init.zeros_(self.decoder[2].weight)
+        torch.nn.init.zeros_(self.decoder[2].bias)
     
     def forward(self, image_infos):
         if "img_idx" in image_infos and not self.in_test_set:


### PR DESCRIPTION
hi, 
In affine transformation module, gradients don't propagate to mlp layers and images embeddings, they are always equal to zero. The affine transformation is only learnt in last layer biases. 
it is due to mlp weight and biases zeros initialization. I propose to initialize only the last layer to zero, to enable gradient propagation. Kept the last layer to 0, able to start train close to identity matrix

thanks
Pierre