### PR TITLE
Adjust test_timesteps

### DIFF
--- a/datasets/driving_dataset.py
+++ b/datasets/driving_dataset.py
@@ -585,7 +585,7 @@ class DrivingDataset(SceneDataset):
         if self.data_cfg.pixel_source.test_image_stride != 0:
             test_timesteps = np.arange(
                 # it makes no sense to have test timesteps before the start timestep
-                self.data_cfg.pixel_source.test_image_stride,
+                max(0,self.data_cfg.pixel_source.test_image_stride-1),
                 self.num_img_timesteps,
                 self.data_cfg.pixel_source.test_image_stride,
             )


### PR DESCRIPTION
Current code uses more train images than expected. For instance, setting `test_image_stride=2`, i.e., using every second image for testing does currently not result in expected behavior of
`test_timesteps=[1,3,5,7...]` but rather `test_timesteps=[2,4,6,8...]` 