### PR TITLE
fix initialization of ball_gaussians of rigidnodes

### DIFF
--- a/models/nodes/rigid.py
+++ b/models/nodes/rigid.py
@@ -79,7 +79,13 @@ class RigidNodes(VanillaGaussians):
         distances = torch.from_numpy(distances)
         avg_dist = distances.mean(dim=-1, keepdim=True).to(self.device)
         avg_dist = avg_dist.clamp(0.002, 100)
-        self._scales = Parameter(torch.log(avg_dist.repeat(1, 3)))
+        if self.ball_gaussians:
+            self._scales = Parameter(torch.log(avg_dist.repeat(1, 1)))
+        else:
+            if self.gaussian_2d:
+                self._scales = Parameter(torch.log(avg_dist.repeat(1, 2)))
+            else:
+                self._scales = Parameter(torch.log(avg_dist.repeat(1, 3)))
         self._quats = Parameter(random_quat_tensor(self.num_points).to(self.device))
         dim_sh = num_sh_bases(self.sh_degree)
         


### PR DESCRIPTION
Thanks for your wonderful job ! However, when I enabled the ball_gaussians option, an error was occured: 

> RuntimeError: Sizes of tensors must match except in dimension 0. Expected size 3 but got size 9 for tensor number 1 in the list.

After some troubleshooting, I found that the overwritten method, `create_from_pcd`, of the `RigidNodes` class incorrectly defined the dimensions of scale when initializing the scales of the ball gaussians. Therefore, I fix it as below: (I'm new to this field, so I can't make sure I'm right)